### PR TITLE
Fix error when uploading inline link with name

### DIFF
--- a/src/sphinx_notion/writers.py
+++ b/src/sphinx_notion/writers.py
@@ -64,7 +64,7 @@ class NotionTranslator(TextTranslator):
                     "type": "text",
                     "text": {
                         "content": node.attributes["name"],
-                        "link": node.attributes["refuri"],
+                        "link": {"type": "url", "url": node.attributes["refuri"]},
                     },
                 }
             return {


### PR DESCRIPTION
Previously:

```
notion_client.errors.APIResponseError: body failed validation: body.children[1].paragraph.rich_text[0].text.link should be an object, `null`, or `undefined`, instead was `"http://example.com/"`.
```

Fixes #12